### PR TITLE
Funcionalidade para Criação de Especialidades

### DIFF
--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/common/persistence/gateways/SpecialtyDocumentGateway.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/common/persistence/gateways/SpecialtyDocumentGateway.java
@@ -1,0 +1,14 @@
+package br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;
+
+public class SpecialtyDocumentGateway {
+
+	public static SpecialtyDocument mapToSpecialtyDocument(final SpecialtyDomain specialtyDomain) {
+		return SpecialtyDocument.baseBuilder()
+			.id(specialtyDomain.getId())
+			.name(specialtyDomain.getName())
+			.build();
+	}
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/common/utils/messageresolver/MessageResolverUtil.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/common/utils/messageresolver/MessageResolverUtil.java
@@ -1,0 +1,21 @@
+package br.com.mbragariano.scheduleadministratorapi.common.utils.messageresolver;
+
+import br.com.mbragariano.scheduleadministratorapi.common.annotations.Util;
+import br.com.mbragariano.scheduleadministratorapi.common.ports.MessageResolverPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+@Util
+@RequiredArgsConstructor
+public class MessageResolverUtil {
+
+	@Qualifier("messageSourceResolverAdapter")
+  private final MessageResolverPort messageResolverPort;
+
+	public String resolveMessageWithoutParams(final String code) {
+		return this.messageResolverPort.resolveMessage(code, new Object[]{}, LocaleContextHolder.getLocale());
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/domains/SpecialtyDomain.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/domains/SpecialtyDomain.java
@@ -1,0 +1,26 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains;
+
+import br.com.mbragariano.scheduleadministratorapi.common.domains.BaseDomain;
+import br.com.mbragariano.scheduleadministratorapi.common.groups.Create;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class SpecialtyDomain extends BaseDomain {
+
+  @NotBlank(groups = Create.class)
+  private String name;
+
+  @Builder(builderMethodName = "baseBuilder")
+  public SpecialtyDomain(final String id, final String name) {
+    super(id);
+
+    this.name = name;
+  }
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/dtos/CreateSpecialtyDto.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/dtos/CreateSpecialtyDto.java
@@ -1,0 +1,12 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class CreateSpecialtyDto {
+
+  public String name;
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/facades/CreateSpecialtyFacade.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/facades/CreateSpecialtyFacade.java
@@ -1,0 +1,9 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.dtos.CreateSpecialtyDto;
+
+public interface CreateSpecialtyFacade {
+
+  String execute(CreateSpecialtyDto createSpecialtyDto);
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/mappers/CreateSpecialtyMapper.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/mappers/CreateSpecialtyMapper.java
@@ -1,0 +1,12 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.mappers;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.dtos.CreateSpecialtyDto;
+
+public class CreateSpecialtyMapper {
+
+	public static SpecialtyDomain mapToSpecialtyDomain(final CreateSpecialtyDto createSpecialtyDto) {
+		return SpecialtyDomain.baseBuilder().name(createSpecialtyDto.name).build();
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/documents/SpecialtyDocument.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/documents/SpecialtyDocument.java
@@ -1,0 +1,28 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents;
+
+import br.com.mbragariano.scheduleadministratorapi.common.persistence.documents.BaseDocument;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@TypeAlias(SpecialtyDocument.TYPE_ALIAS)
+@Document(collection = SpecialtyDocument.COLLECTION_NAME, language = BaseDocument.COLLECTION_DEFAULT_LANGUAGE)
+public class SpecialtyDocument extends BaseDocument {
+
+	public static final String TYPE_ALIAS = "specialty";
+	public static final String COLLECTION_NAME = "specialties";
+
+	@Field
+	public String name;
+
+	@Builder(builderMethodName = "baseBuilder")
+	public SpecialtyDocument(final String id, final String name) {
+		super(id);
+
+		this.name = name;
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/repositories/SpecialtyMongoDbRepositoryAdapter.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/repositories/SpecialtyMongoDbRepositoryAdapter.java
@@ -1,0 +1,66 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.repositories;
+
+import br.com.mbragariano.scheduleadministratorapi.common.annotations.Adapter;
+import br.com.mbragariano.scheduleadministratorapi.common.exceptions.DataBaseException;
+import br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways.SpecialtyDocumentGateway;
+import br.com.mbragariano.scheduleadministratorapi.common.ports.MessageResolverPort;
+import br.com.mbragariano.scheduleadministratorapi.common.utils.messageresolver.MessageResolverUtil;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports.SpecialtyRepositoryPort;
+import com.mongodb.MongoException;
+import com.mongodb.MongoSocketException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+@RequiredArgsConstructor
+@Adapter("specialtyMongoDbRepositoryAdapter")
+public class SpecialtyMongoDbRepositoryAdapter implements SpecialtyRepositoryPort {
+
+	private final MongoTemplate mongoTemplate;
+
+	private final MessageResolverUtil messageResolverUtil;
+
+	private static final String EXCEPTION_MESSAGE_WHEN_CREATE = "specialty.mongodb.repository.adapter.create.database.exception.message";
+	private static final String EXCEPTION_DETAILS_WHEN_CREATE = "specialty.mongodb.repository.adapter.create.database.exception.details";
+
+	private static final String EXCEPTION_MESSAGE_WHEN_FIND_BY_NAME = "specialty.mongodb.repository.adapter.existsByName.database.exception.message";
+	private static final String EXCEPTION_DETAILS_WHEN_FIND_BY_NAME = "specialty.mongodb.repository.adapter.existsByName.database.exception.details";
+
+	@Override
+	public Boolean existsByName(final String name) {
+		try {
+			final var query = new Query(Criteria.where("name").is(name));
+
+			return this.mongoTemplate.exists(query, SpecialtyDocument.class);
+		} catch (final DataAccessException dataAccessException) {
+			dataAccessException.printStackTrace();
+
+			final var message = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_MESSAGE_WHEN_FIND_BY_NAME);
+			final var details = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_DETAILS_WHEN_FIND_BY_NAME);
+
+			throw new DataBaseException(message, details, dataAccessException.getMessage(), null);
+		}
+	}
+
+	@Override
+	public String create(final SpecialtyDomain specialtyDomain) {
+		try {
+			final var specialtyDocument = SpecialtyDocumentGateway.mapToSpecialtyDocument(specialtyDomain);
+
+			return this.mongoTemplate.save(specialtyDocument).id;
+		} catch (final MongoException mongoException) {
+			mongoException.printStackTrace();
+
+			final var message = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_MESSAGE_WHEN_CREATE);
+			final var details = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_DETAILS_WHEN_CREATE);
+
+			throw new DataBaseException(message, details, mongoException.getMessage(), null);
+		}
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/ports/SpecialtyRepositoryPort.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/ports/SpecialtyRepositoryPort.java
@@ -1,0 +1,11 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+
+public interface SpecialtyRepositoryPort {
+
+	Boolean existsByName(String name);
+
+	String create(SpecialtyDomain specialtyDomain);
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/endpoints/CreateSpecialtyRestEndPoint.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/endpoints/CreateSpecialtyRestEndPoint.java
@@ -1,0 +1,33 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.endpoints;
+
+import br.com.mbragariano.scheduleadministratorapi.common.annotations.RestEndPoint;
+import br.com.mbragariano.scheduleadministratorapi.common.presentation.models.response.IdResponse;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades.CreateSpecialtyFacade;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.model.request.CreateSpecialtyRequest;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.presenters.CreateSpecialtyPresenter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Slf4j
+@RestEndPoint
+@RequiredArgsConstructor
+public class CreateSpecialtyRestEndPoint {
+
+	@Qualifier("createSpecialtyUseCase")
+	private final CreateSpecialtyFacade createSpecialtyFacade;
+
+	@PostMapping("/specialty")
+	public ResponseEntity<IdResponse> handle(@RequestBody final CreateSpecialtyRequest createSpecialtyRequest) {
+		final var createdDomainId = this.createSpecialtyFacade.execute(
+			CreateSpecialtyPresenter.mapToCreateSpecialtyDto(createSpecialtyRequest)
+		);
+		return ResponseEntity.status(HttpStatus.CREATED).body(new IdResponse(createdDomainId));
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/model/request/CreateSpecialtyRequest.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/model/request/CreateSpecialtyRequest.java
@@ -1,0 +1,14 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSpecialtyRequest {
+
+	public String name;
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/presenters/CreateSpecialtyPresenter.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/presenters/CreateSpecialtyPresenter.java
@@ -1,0 +1,12 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.presenters;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.dtos.CreateSpecialtyDto;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.model.request.CreateSpecialtyRequest;
+
+public class CreateSpecialtyPresenter {
+
+	public static CreateSpecialtyDto mapToCreateSpecialtyDto(final CreateSpecialtyRequest createSpecialtyRequest) {
+		return new CreateSpecialtyDto(createSpecialtyRequest.name);
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/usecases/CreateSpecialtyUseCase.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/usecases/CreateSpecialtyUseCase.java
@@ -1,0 +1,51 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.usecases;
+
+import br.com.mbragariano.scheduleadministratorapi.common.annotations.UseCase;
+import br.com.mbragariano.scheduleadministratorapi.common.exceptions.DuplicatedEntityException;
+import br.com.mbragariano.scheduleadministratorapi.common.groups.Create;
+import br.com.mbragariano.scheduleadministratorapi.common.utils.messageresolver.MessageResolverUtil;
+import br.com.mbragariano.scheduleadministratorapi.common.utils.validation.ValidationUtil;
+import br.com.mbragariano.scheduleadministratorapi.common.utils.validation.ValidationUtilMessages;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.dtos.CreateSpecialtyDto;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades.CreateSpecialtyFacade;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.mappers.CreateSpecialtyMapper;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports.SpecialtyRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateSpecialtyUseCase implements CreateSpecialtyFacade {
+
+	private final ValidationUtil validationUtil;
+
+	private final MessageResolverUtil messageResolverUtil;
+
+	@Qualifier("specialtyMongoDbRepositoryAdapter")
+	private final SpecialtyRepositoryPort specialtyRepositoryPort;
+
+	private final String VALIDATION_MESSAGE_CODE = "create-specialty-facade.entity-validation-exception.message";
+	private final String VALIDATION_DETAILS_CODE = "create-specialty-facade.entity-validation-exception.details";
+
+	private final String DUPLICATED_ENTITY_EXCEPTION_MESSAGE_CODE = "create-specialty-facade.duplicated-entity-exception.message";
+	private final String DUPLICATED_ENTITY_EXCEPTION_DETAILS_CODE = "create-specialty-facade.duplicated-entity-exception.details";
+
+	@Override
+	public String execute(final CreateSpecialtyDto createSpecialtyDto) {
+		final var existsByName = this.specialtyRepositoryPort.existsByName(createSpecialtyDto.name);
+
+		if (existsByName)
+			throw new DuplicatedEntityException(
+				this.messageResolverUtil.resolveMessageWithoutParams(DUPLICATED_ENTITY_EXCEPTION_MESSAGE_CODE),
+				this.messageResolverUtil.resolveMessageWithoutParams(DUPLICATED_ENTITY_EXCEPTION_DETAILS_CODE),
+				null
+			);
+
+		final var specialtyDomain = CreateSpecialtyMapper.mapToSpecialtyDomain(createSpecialtyDto);
+
+		this.validationUtil.validate(specialtyDomain, new ValidationUtilMessages(VALIDATION_MESSAGE_CODE, VALIDATION_DETAILS_CODE), Create.class);
+
+		return this.specialtyRepositoryPort.create(specialtyDomain);
+	}
+
+}

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -10,5 +10,17 @@ create-specialty-facade.duplicated-entity-exception.details = There is already a
 create-specialty-facade.entity-validation-exception.message = Cannot create specialty
 create-specialty-facade.entity-validation-exception.details = Entered values are invalid, update theirs by validation message and try again
 
+## Specialty Mongo DbRepository Adapter
+
+### Data Base Exception
+
+#### Create
+specialty.mongodb.repository.adapter.create.database.exception.message = Cannot register specialty
+specialty.mongodb.repository.adapter.create.database.exception.details = An error occurred while inserting the specialty
+
+#### Exists By Name
+specialty.mongodb.repository.adapter.existsByName.database.exception.message = Cannot find specialty by name
+specialty.mongodb.repository.adapter.existsByName.database.exception.details = An error occurred while searching a specialty by name
+
 # Javax Validation
 javax.validation.constraints.NotBlank.message = Should not be blank

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -10,5 +10,17 @@ create-specialty-facade.duplicated-entity-exception.details = J\u00E1 existe uma
 create-specialty-facade.entity-validation-exception.message = N\u00E3o foi poss\u00EDvel criar especialidade
 create-specialty-facade.entity-validation-exception.details = Alguns valores inserirdos s\u00E3o inv\u00E1lidos, atualize-os atrav\u00E9s das mensagens de valida\u00E7\u00F5es e tente novamente
 
+## Specialty Mongo DbRepository Adapter
+
+### Data Base Exception
+
+#### Create
+specialty.mongodb.repository.adapter.create.database.exception.message = N\u00E3o foi poss\u00EDvel registrar especialidade
+specialty.mongodb.repository.adapter.create.database.exception.details = Ocorreu um erro ao inserir especialidade
+
+#### Exists By Name
+specialty.mongodb.repository.adapter.existsByName.database.exception.message = N\u00E3o foi poss\u00EDvel busca especialidade pelo nome
+specialty.mongodb.repository.adapter.existsByName.database.exception.details = Ocorreu um erro ao procurar especialidade pelo nome
+
 # Javax Validation
 javax.validation.constraints.NotBlank.message = N\u00E3o pode estar em branco


### PR DESCRIPTION
# Descrição

Essa PR implementa a funcionalidade de criação de uma especialidade, validando a existência de um mesmo registro pelo nome, uma vez que essa propriedade é única por especialidade, juntamente com a entrada de dados segundo as regras dessa tarefa.

# Implementação

Foi criado um endpoint para **/specialty** com o método **POST**, esperando receber no corpo da requisição o seguinte JSON:

```json
{
  "name": "Hair"
}
```

Como já foi implementado a funcionalidade internacionalização, esse ednpoint pode receber o header Accept-Languge com en-US ou pt-BR, respectivamente, representando o inglês americano e português brasileiro. Caso ocorra tudo certo, será retornado um **201 Created** juntamente com id do registro criado. Exemplo:

```json
{
  "id": "5fb5632be5d918280603de25"
}
```

## Duplicidade

Não será possível cadastrar uma especialidade que tenha o mesmo nome de outra especialidade já estrada, então será retornado um **409 Conflict** com o seguinte conteúdo:

```json
{
  "status": 409,
  "message": "Especialidade duplicada pelo nome",
  "details": "Já existe uma especialidade registrada com esse nome",
  "exceptionType": "DuplicatedEntityException",
  "developerMessage": null
}
```

## Entrada de Dados

Não faz sentido registrar uma especialidade sem que a mesma tenha um nome, então para esse caso é validado se existe um valor do tipo **String** e se o mesmo valor não está vazio, caso ocorra uma dessas situações será retornada um **400 Bad Request** com o seguinte conteúdo:

```json
{
  "status": 400,
  "message": "Não foi possível criar especialidade",
  "details": "Alguns valores inserirdos são inválidos, atualize-os através das mensagens de validações e tente novamente",
  "exceptionType": "EntityValidationException",
  "developerMessage": null,
  "validations": [
    {
      "value": "",
      "message": "Não pode estar em branco",
      "relatedWith": "name"
    }
  ]
}
```