### PR TITLE
Buscar Todas as Especialidade

### DIFF
--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/common/persistence/gateways/CreateSpecialtyGateway.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/common/persistence/gateways/CreateSpecialtyGateway.java
@@ -3,7 +3,7 @@ package br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;
 
-public class SpecialtyDocumentGateway {
+public class CreateSpecialtyGateway {
 
 	public static SpecialtyDocument mapToSpecialtyDocument(final SpecialtyDomain specialtyDomain) {
 		return SpecialtyDocument.baseBuilder()

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/facades/FindAllSpecialtiesFacade.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/facades/FindAllSpecialtiesFacade.java
@@ -1,0 +1,11 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+
+import java.util.List;
+
+public interface FindAllSpecialtiesFacade {
+
+	List<SpecialtyDomain> execute();
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/gateways/CreateSpecialtyGateway.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/gateways/CreateSpecialtyGateway.java
@@ -1,4 +1,4 @@
-package br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways;
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.gateways;
 
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/gateways/FindAllSpecialtiesGateway.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/gateways/FindAllSpecialtiesGateway.java
@@ -1,0 +1,22 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.gateways;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FindAllSpecialtiesGateway {
+
+	public static List<SpecialtyDomain> mapToSpecialtyDomains(final List<SpecialtyDocument> specialtyDocuments) {
+		return specialtyDocuments.stream().map(FindAllSpecialtiesGateway::mapToSpecialtyDomains).collect(Collectors.toList());
+	}
+
+	private static SpecialtyDomain mapToSpecialtyDomains(final SpecialtyDocument specialtyDocument) {
+		return SpecialtyDomain.baseBuilder()
+			.id(specialtyDocument.id)
+			.name(specialtyDocument.name)
+			.build();
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/repositories/SpecialtyMongoDbStorage.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/repositories/SpecialtyMongoDbStorage.java
@@ -2,7 +2,7 @@ package br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistenc
 
 import br.com.mbragariano.scheduleadministratorapi.common.annotations.Adapter;
 import br.com.mbragariano.scheduleadministratorapi.common.exceptions.DataBaseException;
-import br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways.CreateSpecialtyGateway;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.gateways.CreateSpecialtyGateway;
 import br.com.mbragariano.scheduleadministratorapi.common.utils.messageresolver.MessageResolverUtil;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/repositories/SpecialtyMongoDbStorage.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/persistence/repositories/SpecialtyMongoDbStorage.java
@@ -2,17 +2,19 @@ package br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistenc
 
 import br.com.mbragariano.scheduleadministratorapi.common.annotations.Adapter;
 import br.com.mbragariano.scheduleadministratorapi.common.exceptions.DataBaseException;
-import br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways.SpecialtyDocumentGateway;
+import br.com.mbragariano.scheduleadministratorapi.common.persistence.gateways.CreateSpecialtyGateway;
 import br.com.mbragariano.scheduleadministratorapi.common.utils.messageresolver.MessageResolverUtil;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.documents.SpecialtyDocument;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports.SpecialtyStorage;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.persistence.gateways.FindAllSpecialtiesGateway;
 import com.mongodb.MongoException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Adapter("specialtyMongoDbStorage")
@@ -25,8 +27,27 @@ public class SpecialtyMongoDbStorage implements SpecialtyStorage {
 	private static final String EXCEPTION_MESSAGE_WHEN_CREATE = "specialty.mongodb.repository.adapter.create.database.exception.message";
 	private static final String EXCEPTION_DETAILS_WHEN_CREATE = "specialty.mongodb.repository.adapter.create.database.exception.details";
 
+	private static final String EXCEPTION_MESSAGE_WHEN_FIND_ALL = "specialty.mongodb.repository.adapter.findAll.database.exception.message";
+	private static final String EXCEPTION_DETAILS_WHEN_FIND_ALL = "specialty.mongodb.repository.adapter.findAll.database.exception.details";
+
 	private static final String EXCEPTION_MESSAGE_WHEN_FIND_BY_NAME = "specialty.mongodb.repository.adapter.existsByName.database.exception.message";
 	private static final String EXCEPTION_DETAILS_WHEN_FIND_BY_NAME = "specialty.mongodb.repository.adapter.existsByName.database.exception.details";
+
+	@Override
+	public List<SpecialtyDomain> findAll() {
+		try {
+			final var specialtyDocuments = this.mongoTemplate.findAll(SpecialtyDocument.class);
+
+			return FindAllSpecialtiesGateway.mapToSpecialtyDomains(specialtyDocuments);
+		} catch (final MongoException mongoException) {
+			mongoException.printStackTrace();
+
+			final var message = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_MESSAGE_WHEN_FIND_ALL);
+			final var details = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_DETAILS_WHEN_FIND_ALL);
+
+			throw new DataBaseException(message, details, mongoException.getMessage(), mongoException.getCode());
+		}
+	}
 
 	@Override
 	public Boolean existsByName(final String name) {
@@ -34,20 +55,20 @@ public class SpecialtyMongoDbStorage implements SpecialtyStorage {
 			final var query = new Query(Criteria.where("name").is(name));
 
 			return this.mongoTemplate.exists(query, SpecialtyDocument.class);
-		} catch (final DataAccessException dataAccessException) {
-			dataAccessException.printStackTrace();
+		} catch (final MongoException mongoException) {
+			mongoException.printStackTrace();
 
 			final var message = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_MESSAGE_WHEN_FIND_BY_NAME);
 			final var details = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_DETAILS_WHEN_FIND_BY_NAME);
 
-			throw new DataBaseException(message, details, dataAccessException.getMessage(), null);
+			throw new DataBaseException(message, details, mongoException.getMessage(), mongoException.getCode());
 		}
 	}
 
 	@Override
 	public void create(final SpecialtyDomain specialtyDomain) {
 		try {
-			final var specialtyDocument = SpecialtyDocumentGateway.mapToSpecialtyDocument(specialtyDomain);
+			final var specialtyDocument = CreateSpecialtyGateway.mapToSpecialtyDocument(specialtyDomain);
 
 			this.mongoTemplate.save(specialtyDocument);
 		} catch (final MongoException mongoException) {
@@ -56,7 +77,7 @@ public class SpecialtyMongoDbStorage implements SpecialtyStorage {
 			final var message = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_MESSAGE_WHEN_CREATE);
 			final var details = this.messageResolverUtil.resolveMessageWithoutParams(EXCEPTION_DETAILS_WHEN_CREATE);
 
-			throw new DataBaseException(message, details, mongoException.getMessage(), null);
+			throw new DataBaseException(message, details, mongoException.getMessage(), mongoException.getCode());
 		}
 	}
 

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/ports/SpecialtyStorage.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/ports/SpecialtyStorage.java
@@ -2,7 +2,11 @@ package br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports;
 
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
 
+import java.util.List;
+
 public interface SpecialtyStorage {
+
+	List<SpecialtyDomain> findAll();
 
 	Boolean existsByName(String name);
 

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/endpoints/CreateSpecialtyRestEndPoint.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/endpoints/CreateSpecialtyRestEndPoint.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@Slf4j
 @RestEndPoint
 @RequiredArgsConstructor
 public class CreateSpecialtyRestEndPoint {

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/endpoints/FindAllSpecialtiesEndPoint.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/endpoints/FindAllSpecialtiesEndPoint.java
@@ -1,0 +1,26 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.endpoints;
+
+import br.com.mbragariano.scheduleadministratorapi.common.annotations.RestEndPoint;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades.FindAllSpecialtiesFacade;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.models.responses.FindAllSpecialtiesResponse;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.presenters.FindAllSpecialtiesPresenter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@RestEndPoint
+@RequiredArgsConstructor
+public class FindAllSpecialtiesEndPoint {
+
+	private final FindAllSpecialtiesFacade findAllSpecialtiesFacade;
+
+	@GetMapping("/specialty")
+	public ResponseEntity<List<FindAllSpecialtiesResponse>> handle() {
+		final var specialtyDomains = this.findAllSpecialtiesFacade.execute();
+
+		return ResponseEntity.ok(FindAllSpecialtiesPresenter.mapToFindAllSpecialtiesResponse(specialtyDomains));
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/models/responses/FindAllSpecialtiesResponse.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/models/responses/FindAllSpecialtiesResponse.java
@@ -1,0 +1,14 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.models.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class FindAllSpecialtiesResponse {
+
+	public String id;
+
+	public String name;
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/presenters/FindAllSpecialtiesPresenter.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/presentation/presenters/FindAllSpecialtiesPresenter.java
@@ -1,0 +1,24 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.presenters;
+
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.presentation.models.responses.FindAllSpecialtiesResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FindAllSpecialtiesPresenter {
+
+	public static List<FindAllSpecialtiesResponse> mapToFindAllSpecialtiesResponse(
+		final List<SpecialtyDomain> specialtyDomains
+	) {
+		return specialtyDomains.stream().map(FindAllSpecialtiesPresenter::mapToFindAllSpecialtiesResponse).collect(Collectors.toList());
+	}
+
+	private static FindAllSpecialtiesResponse mapToFindAllSpecialtiesResponse(final SpecialtyDomain specialtyDomain) {
+		return FindAllSpecialtiesResponse.builder()
+			.id(specialtyDomain.getId())
+			.name(specialtyDomain.getName())
+			.build();
+	}
+
+}

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/usecases/FindAllSpecialtiesUseCase.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/usecases/FindAllSpecialtiesUseCase.java
@@ -3,7 +3,7 @@ package br.com.mbragariano.scheduleadministratorapi.modules.specialty.usecases;
 import br.com.mbragariano.scheduleadministratorapi.common.annotations.UseCase;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
 import br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades.FindAllSpecialtiesFacade;
-import br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports.SpecialtyRepositoryPort;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports.SpecialtyStorage;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -12,11 +12,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FindAllSpecialtiesUseCase implements FindAllSpecialtiesFacade {
 
-	private final SpecialtyRepositoryPort specialtyRepositoryPort;
+	private final SpecialtyStorage specialtyStorage;
 
 	@Override
 	public List<SpecialtyDomain> execute() {
-		return this.specialtyRepositoryPort.findAll();
+		return this.specialtyStorage.findAll();
 	}
 
 }

--- a/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/usecases/FindAllSpecialtiesUseCase.java
+++ b/src/main/java/br/com/mbragariano/scheduleadministratorapi/modules/specialty/usecases/FindAllSpecialtiesUseCase.java
@@ -1,0 +1,22 @@
+package br.com.mbragariano.scheduleadministratorapi.modules.specialty.usecases;
+
+import br.com.mbragariano.scheduleadministratorapi.common.annotations.UseCase;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.domains.SpecialtyDomain;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.facades.FindAllSpecialtiesFacade;
+import br.com.mbragariano.scheduleadministratorapi.modules.specialty.ports.SpecialtyRepositoryPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class FindAllSpecialtiesUseCase implements FindAllSpecialtiesFacade {
+
+	private final SpecialtyRepositoryPort specialtyRepositoryPort;
+
+	@Override
+	public List<SpecialtyDomain> execute() {
+		return this.specialtyRepositoryPort.findAll();
+	}
+
+}

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -14,6 +14,10 @@ create-specialty-facade.entity-validation-exception.details = Entered values are
 
 ### Data Base Exception
 
+#### Find All
+specialty.mongodb.repository.adapter.findAll.database.exception.message = Cannot find all specialties
+specialty.mongodb.repository.adapter.findAll.database.exception.details = An error occurred while searching all specialties in database
+
 #### Create
 specialty.mongodb.repository.adapter.create.database.exception.message = Cannot register specialty
 specialty.mongodb.repository.adapter.create.database.exception.details = An error occurred while inserting the specialty

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -14,6 +14,10 @@ create-specialty-facade.entity-validation-exception.details = Alguns valores ins
 
 ### Data Base Exception
 
+#### Find All
+specialty.mongodb.repository.adapter.findAll.database.exception.message = N\u00E3o foi poss\u00EDvel buscar todas as especialidades
+specialty.mongodb.repository.adapter.findAll.database.exception.details = Ocorreu um erro no banco de dados ao buscar as especialidades
+
 #### Create
 specialty.mongodb.repository.adapter.create.database.exception.message = N\u00E3o foi poss\u00EDvel registrar especialidade
 specialty.mongodb.repository.adapter.create.database.exception.details = Ocorreu um erro ao inserir especialidade


### PR DESCRIPTION
# Descrição

Essa PR implementa a funcionalidade de busca por todas as especialidades, pois futuramente quando criar um usuário com uma especialidade associada será necessário listar todas as especialidades registradas no banco de dados, para que possa selecionar aquelas de sua escolha.

# Implementação

Foi criado um endpoint para **/specialty** com o método **GET**, sem entrada de parâmetros. Segue um exemplo de conteúdo retornado:

```json
[
  {
    "id": "5fb5632be5d918280603de25",
    "name": "Cabelo"
  },
  {
    "id": "5fb812a2ff9b544650cf7067",
    "name": "Depilação"
  },
  {
    "id": "5fbbecea76d8e74ef018fdbe",
    "name": "Unhas"
  }
]
```